### PR TITLE
Fix Yahoo OAuth configuration and env loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,11 +212,11 @@ npm start
 1. Copy the example environment file and update it with your Yahoo credentials:
 
 ```
-cp .env.example .env
+cp server/.env.example server/.env
 ```
 
    * `SESSION_SECRET` should be a long random string.
-   * Replace the Yahoo values with the consumer key/secret that you registered in the [Yahoo Developer Portal](https://developer.yahoo.com/apps/).
+   * Replace the Yahoo values with the consumer key/secret that you registered in the [Yahoo Developer Portal](https://developer.yahoo.com/apps/). Both `YAHOO_CLIENT_ID`/`YAHOO_CLIENT_SECRET` and their `YAHOO_CONSUMER_*` aliases are supported.
    * Adjust `YAHOO_REDIRECT_URI` if your server runs on a different host or port.
 
 2. Navigate to the `server` directory:

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,16 @@
+# Server configuration
 PORT=5000
-YAHOO_CLIENT_ID=
-YAHOO_CLIENT_SECRET=
-YAHOO_REDIRECT_URI=http://localhost:5000/api/auth/yahoo/callback
-SESSION_SECRET=dev-secret
+CLIENT_ORIGIN=http://localhost:3000
+SESSION_SECRET=replace-with-a-secure-random-string
+
+# Yahoo OAuth credentials
+# You can provide either the CLIENT_* variables or the CONSUMER_* aliases.
+YAHOO_CLIENT_ID=dj0yJmk9eFJMT3U2YjNjWGZxJmQ9WVdrOVJWQm5TamswVmpZbWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PTU3
+YAHOO_CLIENT_SECRET=bbb596ed665de00fe2d07cde9f1795bbd3915a0d
+YAHOO_CONSUMER_KEY=dj0yJmk9eFJMT3U2YjNjWGZxJmQ9WVdrOVJWQm5TamswVmpZbWNHbzlNQT09JnM9Y29uc3VtZXJzZWNyZXQmc3Y9MCZ4PTU3
+YAHOO_CONSUMER_SECRET=bbb596ed665de00fe2d07cde9f1795bbd3915a0d
+
+# Optional overrides
+# YAHOO_REDIRECT_URI=http://localhost:5000/api/auth/yahoo/callback
+# YAHOO_SCOPE=fspt-r fspt-w
+# LOG_LEVEL=info

--- a/server/__tests__/yahoo-config.test.js
+++ b/server/__tests__/yahoo-config.test.js
@@ -1,0 +1,50 @@
+const ORIGINAL_ENV = { ...process.env };
+
+const loadYahooModule = () => {
+  let yahoo;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line global-require
+    yahoo = require('../lib/yahoo');
+  });
+  return yahoo;
+};
+
+describe('Yahoo OAuth configuration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('falls back to the Yahoo consumer key aliases when client variables are absent', () => {
+    delete process.env.YAHOO_CLIENT_ID;
+    delete process.env.YAHOO_CLIENT_SECRET;
+    process.env.YAHOO_CONSUMER_KEY = 'alias-client-id';
+    process.env.YAHOO_CONSUMER_SECRET = 'alias-client-secret';
+    process.env.NODE_ENV = 'production';
+
+    const { buildAuthUrl } = loadYahooModule();
+    const fakeRequest = {
+      protocol: 'http',
+      get: () => 'localhost:5000',
+    };
+
+    const authUrl = buildAuthUrl(fakeRequest, 'state123');
+    const params = new URL(authUrl).searchParams;
+
+    expect(params.get('client_id')).toBe('alias-client-id');
+  });
+
+  it('throws a descriptive error when credentials are missing in production', () => {
+    delete process.env.YAHOO_CLIENT_ID;
+    delete process.env.YAHOO_CLIENT_SECRET;
+    delete process.env.YAHOO_CONSUMER_KEY;
+    delete process.env.YAHOO_CONSUMER_SECRET;
+    process.env.NODE_ENV = 'production';
+
+    expect(() => loadYahooModule()).toThrow(/Yahoo OAuth credentials missing/i);
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,15 @@
-require('dotenv').config();
-
+const fs = require('fs');
 const path = require('path');
+const dotenv = require('dotenv');
+
+const loadEnvFile = (envPath, options = {}) => {
+  if (fs.existsSync(envPath)) {
+    dotenv.config({ path: envPath, override: false, ...options });
+  }
+};
+
+loadEnvFile(path.resolve(__dirname, '../.env'));
+loadEnvFile(path.resolve(__dirname, '.env'), { override: true });
 const express = require('express');
 const cors = require('cors');
 const session = require('express-session');


### PR DESCRIPTION
## Summary
- ensure the server loads environment variables from local .env files and warn when Yahoo OAuth credentials fall back to defaults
- update Yahoo OAuth helper to support Yahoo consumer key aliases and add regression tests for the configuration logic
- refresh the sample environment file and documentation with the provided Yahoo credentials and setup guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e53ed58f98832d878db5760595b7e5